### PR TITLE
made builder use completely local turf

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This simple UI enables users to generate custom browserify builds of Turf.js wit
 
 
 ###Installation
-Download the code and place it in a folder called 'Build' in folder containing a copy of the Turf repo. Once you've done that run the following in your command line from the build directory 
+Download, then run the following in your command line from the build directory 
 ````
 npm install
 ````

--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ app.get("/build", function(req, res){
 	fs.writeFile(__dirname + '/outputs/temp.js', outputFileString);
 
 	var b = browserify('./outputs/temp.js',{
-		standalone:"turf"
+		standalone:"turf",
+		paths: ['./node_modules/turf/node_modules']
 	});
 
 	b.transform({
@@ -61,7 +62,7 @@ app.get("/build", function(req, res){
 
 
 var turfModules =[];
-var turfLocation = '../node_modules';
+var turfLocation = 'node_modules/turf/node_modules';
 
 var startup = (function checkExistance(){
 	

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "url": "https://github.com/rowanwins/turf-builder/issues"
   },
   "dependencies": {
-    "express": "4.13.3",
+    "browserify": "^11.1.0",
     "ejs": "2.3.3",
+    "express": "4.13.3",
     "opener": "1.4.1",
+    "turf": "^2.0.2",
     "uglifyify": "3.0.1"
   }
 }


### PR DESCRIPTION
By installing `turf` as a dependency, turf-builder no longer needs to be installed inside of an existing turf install. This means that it can be totally standalone :tada:

![](http://i.giphy.com/TyPKuTkBXmBPO.gif)
