### PR TITLE
camelCase multi-word module names to match canonical turf modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,13 @@ app.get("/build", function(req, res){
 
 	for (var i = 0; i < requiredModules.length; i++ ) {
 		var plainModuleName = requiredModules[i].replace("turf-","");
+		plainModuleName = plainModuleName.split("-").map(function(elem, ind) {
+			if (ind > 0) { 
+				return elem.slice(0, 1).toUpperCase()+elem.slice(1); 
+			}
+			return elem;
+		}).join("");
+		
 		outputFileString += plainModuleName + ": require('"+ requiredModules[i] +"'),";
 	}
 


### PR DESCRIPTION
previously, modules like `line-distance` `square-grid`, etc would generate invalid keys in the output file. Now they're valid, and match the standard names used in real turf - `turf.lineDistance()`, `turf.squareGrid()`
